### PR TITLE
Don't update redis when weight = 0

### DIFF
--- a/ratelimitj-redis/src/main/resources/sliding-window-ratelimit.lua
+++ b/ratelimitj-redis/src/main/resources/sliding-window-ratelimit.lua
@@ -63,13 +63,15 @@ for i, limit in ipairs(limits) do
 end
 
 -- there is enough resources, update the counts IFF needed
-for i, limit in ipairs(limits) do
-    local saved = saved_keys[i]
-    for j, key in ipairs(KEYS) do
-         -- update the current timestamp, count, and bucket count
-         redis.call('HSET', key, saved.ts_key, saved.trim_before)
-         redis.call('HINCRBY', key, saved.count_key, weight)
-         redis.call('HINCRBY', key, saved.count_key .. saved.block_id, weight)
+if weight ~= 0 then
+    for i, limit in ipairs(limits) do
+        local saved = saved_keys[i]
+        for j, key in ipairs(KEYS) do
+            -- update the current timestamp, count, and bucket count
+            redis.call('HSET', key, saved.ts_key, saved.trim_before)
+            redis.call('HINCRBY', key, saved.count_key, weight)
+            redis.call('HINCRBY', key, saved.count_key .. saved.block_id, weight)
+        end
     end
 end
 


### PR DESCRIPTION
Don't store vacuous 0-weight counts in redis.

In my use case I check whether a limit has already been exceeded by checking >= limit with weight 0, and I saw that this was unexpectedly and needlessly creating and updating the key each time.