### PR TITLE
Add support key specific rules.

### DIFF
--- a/ratelimitj-core/src/main/java/es/moki/ratelimitj/core/limiter/request/DefaultRequestLimitRulesSupplier.java
+++ b/ratelimitj-core/src/main/java/es/moki/ratelimitj/core/limiter/request/DefaultRequestLimitRulesSupplier.java
@@ -1,0 +1,26 @@
+package es.moki.ratelimitj.core.limiter.request;
+
+import java.util.Map;
+import java.util.Set;
+
+public class DefaultRequestLimitRulesSupplier implements RequestLimitRulesSupplier<Set<RequestLimitRule>> {
+
+    private Set<RequestLimitRule> defaultRules;
+
+    private Map<String, Set<RequestLimitRule>> ruleMap;
+
+    public DefaultRequestLimitRulesSupplier(Set<RequestLimitRule> rules) {
+        this.defaultRules = RequestLimitRulesSupplier.buildDefaultRuleSet(rules);
+        this.ruleMap = RequestLimitRulesSupplier.buildRuleMap(rules);
+    }
+
+    @Override
+    public Set<RequestLimitRule> getRules(String key) {
+        Set<RequestLimitRule> ruleSet = ruleMap.get(key);
+        if (ruleSet != null) {
+            return ruleSet;
+        }
+        return defaultRules;
+    }
+
+}

--- a/ratelimitj-core/src/main/java/es/moki/ratelimitj/core/limiter/request/RequestLimitRule.java
+++ b/ratelimitj-core/src/main/java/es/moki/ratelimitj/core/limiter/request/RequestLimitRule.java
@@ -1,7 +1,10 @@
 package es.moki.ratelimitj.core.limiter.request;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
@@ -16,16 +19,22 @@ public class RequestLimitRule {
     private final long limit;
     private final int precision;
     private final String name;
+    private final Set<String> keys;
 
     private RequestLimitRule(int durationSeconds, long limit, int precision) {
         this(durationSeconds, limit, precision, null);
     }
 
     private RequestLimitRule(int durationSeconds, long limit, int precision, String name) {
+        this(durationSeconds, limit, precision, name, null);
+    }
+
+    private RequestLimitRule(int durationSeconds, long limit, int precision, String name, Set<String> keys) {
         this.durationSeconds = durationSeconds;
         this.limit = limit;
         this.precision = precision;
         this.name = name;
+        this.keys = keys;
     }
 
     /**
@@ -50,7 +59,7 @@ public class RequestLimitRule {
      * @return a limit rule
      */
     public RequestLimitRule withPrecision(int precision) {
-        return new RequestLimitRule(this.durationSeconds, this.limit, precision, this.name);
+        return new RequestLimitRule(this.durationSeconds, this.limit, precision, this.name, this.keys);
     }
 
     /**
@@ -60,7 +69,28 @@ public class RequestLimitRule {
      * @return a limit rule
      */
     public RequestLimitRule withName(String name) {
-        return new RequestLimitRule(this.durationSeconds, this.limit, this.precision, name);
+        return new RequestLimitRule(this.durationSeconds, this.limit, this.precision, name, this.keys);
+    }
+
+    /**
+     * Applies a key to the rate limit that defines to which keys, the rule applies, empty for any unmatched key.
+     *
+     * @param keys Defines a set of keys to which the rule applies.
+     * @return a limit rule
+     */
+    public RequestLimitRule withKeys(String... keys) {
+        Set<String> keySet = keys.length > 0 ? new HashSet<>(Arrays.asList(keys)) : null;
+        return withKeys(keySet);
+    }
+
+    /**
+     * Applies a key to the rate limit that defines to which keys, the rule applies, null for any unmatched key.
+     *
+     * @param keys Defines a set of keys to which the rule applies.
+     * @return a limit rule
+     */
+    public RequestLimitRule withKeys(Set<String> keys) {
+        return new RequestLimitRule(this.durationSeconds, this.limit, this.precision, this.name, keys);
     }
 
     /**
@@ -91,6 +121,12 @@ public class RequestLimitRule {
         return limit;
     }
 
+    /**
+     * @return The keys.
+     */
+    public Set<String> getKeys() {
+        return keys;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -104,11 +140,12 @@ public class RequestLimitRule {
         return durationSeconds == that.durationSeconds
                 && limit == that.limit
                 && Objects.equals(precision, that.precision)
-                && Objects.equals(name, that.name);
+                && Objects.equals(name, that.name)
+                && Objects.equals(keys, that.keys);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(durationSeconds, limit, precision, name);
+        return Objects.hash(durationSeconds, limit, precision, name, keys);
     }
 }

--- a/ratelimitj-core/src/main/java/es/moki/ratelimitj/core/limiter/request/RequestLimitRulesSupplier.java
+++ b/ratelimitj-core/src/main/java/es/moki/ratelimitj/core/limiter/request/RequestLimitRulesSupplier.java
@@ -1,0 +1,54 @@
+package es.moki.ratelimitj.core.limiter.request;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public interface RequestLimitRulesSupplier<T> {
+
+    /**
+     * Build the default rule set.
+     * @param rules
+     *      The complete rule set.
+     * @return
+     *      The rule set for any key that doesn't match a specific rule set.
+     */
+    static Set<RequestLimitRule> buildDefaultRuleSet(Set<RequestLimitRule> rules) {
+        return rules.stream()
+                .filter( rule -> rule.getKeys() == null )
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Build the rule map.
+     * @param rules
+     *      The complete rule set.
+     * @return
+     *      A map of rule set by key.
+     */
+    static Map<String,Set<RequestLimitRule>> buildRuleMap(Set<RequestLimitRule> rules) {
+        Map<String, Set<RequestLimitRule>> ruleMap = new HashMap<>();
+
+        for (RequestLimitRule rule : rules) {
+            if (rule.getKeys() == null) {
+                continue;
+            }
+            for (String key : rule.getKeys()) {
+                ruleMap.computeIfAbsent(key, k -> new HashSet<>()).add(rule);
+            }
+        }
+        return ruleMap;
+    }
+
+    /**
+     * Provides the rule set for the given key.
+     * @param key
+     *      The key for which the rule set should be provided.
+     * @return
+     *      The rule set for the given key.
+     */
+    T getRules(String key);
+
+}

--- a/ratelimitj-core/src/test/java/es/moki/ratelimitj/core/limiter/request/DefaultRequestLimitRulesSupplierTest.java
+++ b/ratelimitj-core/src/test/java/es/moki/ratelimitj/core/limiter/request/DefaultRequestLimitRulesSupplierTest.java
@@ -1,0 +1,61 @@
+package es.moki.ratelimitj.core.limiter.request;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+class DefaultRequestLimitRulesSupplierTest {
+
+    private final Set<RequestLimitRule> allRules = new HashSet<>();
+    private final RequestLimitRulesSupplier<Set<RequestLimitRule>> requestLimitRulesSupplier;
+
+    DefaultRequestLimitRulesSupplierTest() {
+        allRules.add(RequestLimitRule.of(1, TimeUnit.SECONDS, 10).withName("localhostPerSeconds")
+                .withKeys("localhost", "127.0.0.1"));
+        allRules.add(RequestLimitRule.of(1, TimeUnit.HOURS, 2000).withName("localhostPerHours")
+                .withKeys("localhost", "127.0.0.1"));
+        allRules.add(RequestLimitRule.of(1, TimeUnit.SECONDS, 5).withName("perSeconds"));
+        allRules.add(RequestLimitRule.of(1, TimeUnit.HOURS, 1000).withName("perHours"));
+        requestLimitRulesSupplier = new DefaultRequestLimitRulesSupplier(allRules);
+    }
+
+    @Test
+    void shouldContainsDefaultRules() {
+        Set<String> ruleNames = requestLimitRulesSupplier.getRules("other")
+                .stream()
+                .map(RequestLimitRule::getName)
+                .collect(Collectors.toSet());
+
+        assertThat(ruleNames).hasSize(2);
+        assertThat(ruleNames).contains("perSeconds", "perHours");
+    }
+
+    @Test
+    void shouldContainLocalhostRulesForLocalhost() {
+        Set<String> ruleNames = requestLimitRulesSupplier.getRules("localhost")
+                .stream()
+                .map(RequestLimitRule::getName)
+                .collect(Collectors.toSet());
+
+        assertThat(ruleNames).hasSize(2);
+        assertThat(ruleNames).contains("localhostPerSeconds", "localhostPerHours");
+    }
+
+    @Test
+    void shouldContainLocalhostRulesFor127_0_0_1() {
+        Set<String> ruleNames = requestLimitRulesSupplier.getRules("127.0.0.1")
+                .stream()
+                .map(RequestLimitRule::getName)
+                .collect(Collectors.toSet());
+
+        assertThat(ruleNames).hasSize(2);
+        assertThat(ruleNames).contains("localhostPerSeconds", "localhostPerHours");
+    }
+
+}

--- a/ratelimitj-redis/src/main/java/es/moki/ratelimitj/redis/request/SerializedRequestLimitRulesSupplier.java
+++ b/ratelimitj-redis/src/main/java/es/moki/ratelimitj/redis/request/SerializedRequestLimitRulesSupplier.java
@@ -1,0 +1,35 @@
+package es.moki.ratelimitj.redis.request;
+
+import es.moki.ratelimitj.core.limiter.request.RequestLimitRule;
+import es.moki.ratelimitj.core.limiter.request.RequestLimitRulesSupplier;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SerializedRequestLimitRulesSupplier implements RequestLimitRulesSupplier<String> {
+
+    private final LimitRuleJsonSerialiser serialiser = new LimitRuleJsonSerialiser();
+
+    private final Map<String,String> serializedRuleMap;
+
+    private final String serializedDefaultRuleSet;
+
+    SerializedRequestLimitRulesSupplier(Set<RequestLimitRule> rules) {
+        this.serializedRuleMap = RequestLimitRulesSupplier.buildRuleMap(rules)
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap( kv -> kv.getKey(), kv -> serialiser.encode(kv.getValue()) ));
+        this.serializedDefaultRuleSet = serialiser.encode(RequestLimitRulesSupplier.buildDefaultRuleSet(rules));
+    }
+
+    @Override
+    public String getRules(String key) {
+        String rules = serializedRuleMap.get(key);
+        if (rules != null) {
+            return rules;
+        }
+        return serializedDefaultRuleSet;
+    }
+
+}


### PR DESCRIPTION
Hello, I would like to propose this change that allows the definition of rule set specific to one or more keys. This is helpful, if you want different quotas depending of the origin of the request for example.