### PR TITLE
Update dependencies to latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
 }
 
 plugins {
-    id "com.avast.gradle.docker-compose" version "0.13.3"
-    id "net.ltgt.errorprone" version "1.2.1" apply false
+    id "com.avast.gradle.docker-compose" version "0.14.0"
+    id "net.ltgt.errorprone" version "1.3.0" apply false
 }
 
 defaultTasks 'check'

--- a/ratelimitj-aerospike/build.gradle
+++ b/ratelimitj-aerospike/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 
     api(
             project(':ratelimitj-core'),
-            'com.aerospike:aerospike-client:4.4.18',
+            'com.aerospike:aerospike-client:5.0.3',
     )
 
     implementation(

--- a/ratelimitj-core/build.gradle
+++ b/ratelimitj-core/build.gradle
@@ -5,7 +5,7 @@ project.ext.release = true
 dependencies {
 
     api(
-            'io.projectreactor:reactor-core:3.3.10.RELEASE',
+            'io.projectreactor:reactor-core:3.4.2',
     )
 
     implementation(

--- a/ratelimitj-dropwizard/build.gradle
+++ b/ratelimitj-dropwizard/build.gradle
@@ -2,7 +2,7 @@ description 'RateLimitJ Dropwizard'
 
 project.ext.release = true
 
-ext.dropWizardVersion = '2.0.13'
+ext.dropWizardVersion = '2.0.19'
 
 dependencies {
 

--- a/ratelimitj-examples/build.gradle
+++ b/ratelimitj-examples/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     implementation(
             project(':ratelimitj-inmemory'),
             libraries.slf4j,
-            'javax.servlet:javax.servlet-api:4.0.0'
+            'javax.servlet:javax.servlet-api:4.0.1'
     )
 
     testImplementation(

--- a/ratelimitj-hazelcast/build.gradle
+++ b/ratelimitj-hazelcast/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 
     api(
             project(':ratelimitj-core'),
-            'com.hazelcast:hazelcast:3.9.1',
+            'com.hazelcast:hazelcast:4.1.1',
     )
     
     implementation(

--- a/ratelimitj-hazelcast/src/main/java/es/moki/ratelimitj/hazelcast/HazelcastSlidingWindowRequestRateLimiter.java
+++ b/ratelimitj-hazelcast/src/main/java/es/moki/ratelimitj/hazelcast/HazelcastSlidingWindowRequestRateLimiter.java
@@ -2,7 +2,7 @@ package es.moki.ratelimitj.hazelcast;
 
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
+import com.hazelcast.map.IMap;
 import es.moki.ratelimitj.core.limiter.request.DefaultRequestLimitRulesSupplier;
 import es.moki.ratelimitj.core.limiter.request.RequestLimitRule;
 import es.moki.ratelimitj.core.limiter.request.RequestRateLimiter;

--- a/ratelimitj-hazelcast/src/test/java/es/moki/ratelimitj/hazelcast/HazelcastRequestRateLimiterInternalTest.java
+++ b/ratelimitj-hazelcast/src/test/java/es/moki/ratelimitj/hazelcast/HazelcastRequestRateLimiterInternalTest.java
@@ -4,7 +4,7 @@ package es.moki.ratelimitj.hazelcast;
 import com.google.common.collect.ImmutableSet;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
+import com.hazelcast.map.IMap;
 import es.moki.ratelimitj.core.limiter.request.RequestLimitRule;
 import es.moki.ratelimitj.core.limiter.request.RequestRateLimiter;
 import es.moki.ratelimitj.core.time.TimeSupplier;
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import static es.moki.ratelimitj.hazelcast.HazelcastTestFactory.newStandaloneHazelcastInstance;

--- a/ratelimitj-redis/build.gradle
+++ b/ratelimitj-redis/build.gradle
@@ -6,11 +6,11 @@ dependencies {
 
     api(
             project(':ratelimitj-core'),
-            'io.lettuce:lettuce-core:5.3.4.RELEASE'
+            'io.lettuce:lettuce-core:6.0.2.RELEASE'
     )
 
     implementation(
-            'com.eclipsesource.minimal-json:minimal-json:0.9.4',
+            'com.eclipsesource.minimal-json:minimal-json:0.9.5',
             libraries.slf4j
     )
 


### PR DESCRIPTION
Updates the dependencies to latest versions.

This will fix the issue when using `projectreactor` version **3.4.x** where the deprecated retry method:

`Flux<T> retry(long numRetries, Predicate<? super Throwable> retryMatcher)` 

has been removed.