### PR TITLE
Adding backoff periods to core and redis modules

### DIFF
--- a/ratelimitj-core/src/test/java/es/moki/ratelimitj/core/limiter/request/RequestLimitRuleTest.java
+++ b/ratelimitj-core/src/test/java/es/moki/ratelimitj/core/limiter/request/RequestLimitRuleTest.java
@@ -46,6 +46,13 @@ class RequestLimitRuleTest {
     }
 
     @Test
+    void shouldHaveBackoffOf10() {
+        RequestLimitRule requestLimitRule = RequestLimitRule.of(Duration.ofSeconds(1), 5).withBackoff(Duration.ofSeconds(10));
+
+        assertThat(requestLimitRule.getBackoffSeconds()).isEqualTo(10);
+    }
+
+    @Test
     void shouldHaveNameOfBoom() {
         RequestLimitRule requestLimitRule = RequestLimitRule.of(Duration.ofSeconds(1), 5).withName("boom");
 
@@ -59,7 +66,23 @@ class RequestLimitRuleTest {
 
     @Test
     void shouldHaveDurationGreaterThanOneSecond() {
-        assertThatThrownBy(() -> RequestLimitRule.of(Duration.ofMillis(100), 1).withName("boom")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> RequestLimitRule.of(Duration.ofMillis(100), 1).withName("boom"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("duration must be greater than 1 second");
+    }
+
+    @Test
+    void shouldHavePrecisionGreaterThanOneSecond() {
+        assertThatThrownBy(() -> RequestLimitRule.of(Duration.ofSeconds(20), 1).withPrecision(Duration.ofMillis(100)).withName("boom"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("precision must be greater than 1 second");
+    }
+
+    @Test
+    void shouldHaveBackoffGreaterThanDuration() {
+        assertThatThrownBy(() -> RequestLimitRule.of(Duration.ofSeconds(1), 1).withBackoff(Duration.ofMillis(100)).withName("boom"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("backoff must be greater than 1 second");
     }
 
 }

--- a/ratelimitj-redis/src/main/java/es/moki/ratelimitj/redis/request/LimitRuleJsonSerialiser.java
+++ b/ratelimitj-redis/src/main/java/es/moki/ratelimitj/redis/request/LimitRuleJsonSerialiser.java
@@ -17,6 +17,7 @@ class LimitRuleJsonSerialiser {
         return Json.array().asArray()
                 .add(rule.getDurationSeconds())
                 .add(rule.getLimit())
-                .add(rule.getPrecisionSeconds());
+                .add(rule.getPrecisionSeconds())
+                .add(rule.getBackoffSeconds());
     }
 }

--- a/ratelimitj-redis/src/main/resources/sliding-window-ratelimit.lua
+++ b/ratelimitj-redis/src/main/resources/sliding-window-ratelimit.lua
@@ -5,6 +5,7 @@ local now = tonumber(ARGV[2])
 local weight = tonumber(ARGV[3] or '1')
 local strictly_greater = tonumber(ARGV[4] or '1') == 1
 local longest_duration = limits[1][1] or 0
+local longest_applied_backoff = 0
 local saved_keys = {}
 local ge_limit = '0'
 
@@ -13,6 +14,7 @@ for i, limit in ipairs(limits) do
     local duration = limit[1]
     longest_duration = math.max(longest_duration, duration)
     local precision = limit[3] or duration
+    local backoff = limit[4] or 0
     precision = math.min(precision, duration)
     local blocks = math.ceil(duration / precision)
     local saved = {}
@@ -21,6 +23,9 @@ for i, limit in ipairs(limits) do
     saved.trim_before = saved.block_id - blocks + 1
     saved.count_key = duration .. ':' .. precision .. ':'
     saved.ts_key = saved.count_key .. 'o'
+    saved.backoff_key = saved.count_key .. 'bo'
+    saved.backoff_ts_key = saved.backoff_key .. ':ts'
+    saved.backoff = backoff
 
     for j, key in ipairs(KEYS) do
         local old_ts = redis.call('HGET', key, saved.ts_key)
@@ -41,6 +46,21 @@ for i, limit in ipairs(limits) do
                 table.insert(dele, bkey)
             end
         end
+
+        if (saved.backoff > 0) then -- only if backoff is enabled for this rule
+            local applied_backoff = redis.call('HGET', key, saved.backoff_key)
+
+            if (applied_backoff == '1') then -- backoff is in place
+                local applied_backoff_ts = redis.call('HGET', key, saved.backoff_ts_key) or 0
+
+                if (now - tonumber(applied_backoff_ts) > saved.backoff) then -- backoff expired
+                    redis.call('HDEL', key, unpack({ saved.backoff_key, saved.backoff_ts_key }))
+                else
+                    return '1' -- backoff still in place, don't record request
+                end
+            end
+        end
+
         -- handle cleanup
         local cur
         if #dele > 0 then
@@ -54,6 +74,14 @@ for i, limit in ipairs(limits) do
         end
         -- check our limits
         local count = tonumber(cur or '0') + weight
+
+        if (saved.backoff > 0 and (count == limit[2])) then -- at limit, apply backoff for further calls
+            redis.call('HSET', key, saved.backoff_key, '1')
+            redis.call('HSET', key, saved.backoff_ts_key, now)
+
+            longest_applied_backoff = math.max(longest_applied_backoff, saved.backoff)
+        end
+
         if count > limit[2] then
             return '1' -- over limit, don't record request
         elseif count == limit[2] and not strictly_greater then
@@ -75,11 +103,12 @@ if weight ~= 0 then
     end
 end
 
--- We calculated the longest-duration limit so we can EXPIRE
+-- We calculated the longest-duration and longest-applied-backoff limit so we can EXPIRE
 -- the whole HASH for quick and easy idle-time cleanup :)
-if longest_duration > 0 then
+local longest_expire = math.max(longest_applied_backoff, longest_duration)
+if longest_expire > 0 then
     for _, key in ipairs(KEYS) do
-        redis.call('EXPIRE', key, longest_duration)
+        redis.call('EXPIRE', key, longest_expire)
     end
 end
 return ge_limit

--- a/ratelimitj-redis/src/test/java/es/moki/ratelimitj/redis/request/RedisSlidingWindowSyncRequestRateLimiterTest.java
+++ b/ratelimitj-redis/src/test/java/es/moki/ratelimitj/redis/request/RedisSlidingWindowSyncRequestRateLimiterTest.java
@@ -1,22 +1,26 @@
 package es.moki.ratelimitj.redis.request;
 
+import com.google.common.collect.ImmutableSet;
 import es.moki.ratelimitj.core.limiter.request.RequestLimitRule;
 import es.moki.ratelimitj.core.limiter.request.RequestRateLimiter;
 import es.moki.ratelimitj.core.time.TimeSupplier;
 import es.moki.ratelimitj.redis.extensions.RedisStandaloneConnectionSetupExtension;
 import es.moki.ratelimitj.test.limiter.request.AbstractSyncRequestRateLimiterTest;
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.api.StatefulRedisConnection;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
+import es.moki.ratelimitj.test.time.TimeBanditSupplier;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Set;
-
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class RedisSlidingWindowSyncRequestRateLimiterTest extends AbstractSyncRequestRateLimiterTest {
+
+    private final TimeBanditSupplier timeBandit = new TimeBanditSupplier();
 
     @RegisterExtension
     static RedisStandaloneConnectionSetupExtension extension = new RedisStandaloneConnectionSetupExtension();
@@ -24,5 +28,49 @@ public class RedisSlidingWindowSyncRequestRateLimiterTest extends AbstractSyncRe
     @Override
     protected RequestRateLimiter getRateLimiter(Set<RequestLimitRule> rules, TimeSupplier timeSupplier) {
         return new RedisSlidingWindowRequestRateLimiter(extension.getScriptingReactiveCommands(), extension.getKeyReactiveCommands(), rules, timeSupplier);
+    }
+
+    @Test
+    void shouldRateLimitOverTimeWithBackoff() {
+        RequestLimitRule rule1 = RequestLimitRule.of(Duration.ofSeconds(5), 10).withPrecision(Duration.ofSeconds(1)).withBackoff(Duration.ofSeconds(30));
+        RequestRateLimiter requestRateLimiter = getRateLimiter(ImmutableSet.of(rule1), timeBandit);
+        AtomicLong timeOfLastOperation = new AtomicLong(timeBandit.get());
+
+        IntStream.rangeClosed(1, 20).forEach(loop -> {
+
+            IntStream.rangeClosed(1, 250).forEach(value -> {
+                timeBandit.addUnixTimeMilliSeconds(14L);
+                boolean overLimit = requestRateLimiter.overLimitWhenIncremented("ip:127.3.9.3");
+
+                if (overLimit) {
+                    long timeSinceLastOperation = timeBandit.get() - timeOfLastOperation.get();
+                    assertThat(timeSinceLastOperation).isLessThanOrEqualTo(30);
+                } else {
+                    timeOfLastOperation.set(timeBandit.get());
+                }
+            });
+        });
+    }
+
+    @Test
+    void shouldRateLimitForSingleRuleWithBackoff() {
+        RequestLimitRule rule1 = RequestLimitRule.of(Duration.ofSeconds(5), 10).withPrecision(Duration.ofSeconds(1)).withBackoff(Duration.ofSeconds(30));
+        RequestRateLimiter requestRateLimiter = getRateLimiter(ImmutableSet.of(rule1), timeBandit);
+
+        // Allow first 10 requests
+        IntStream.rangeClosed(1, 10).forEach(loop -> {
+            timeBandit.addUnixTimeMilliSeconds(200L);
+            assertThat(requestRateLimiter.overLimitWhenIncremented("ip:127.3.9.3")).isFalse();
+        });
+
+        // Block for the next 30 seconds
+        IntStream.rangeClosed(1, 6).forEach(loop -> {
+            timeBandit.addUnixTimeMilliSeconds(TimeUnit.SECONDS.toMillis(5));
+            assertThat(requestRateLimiter.overLimitWhenIncremented("ip:127.3.9.3")).isTrue();
+        });
+
+        // Allow again after the backoff is gone
+        timeBandit.addUnixTimeMilliSeconds(TimeUnit.SECONDS.toMillis(1));
+        assertThat(requestRateLimiter.overLimitWhenIncremented("ip:127.3.9.3")).isFalse();
     }
 }

--- a/ratelimitj-redis/src/test/java/es/moki/ratelimitj/redis/request/RequestLimitRuleJsonSerialiserTest.java
+++ b/ratelimitj-redis/src/test/java/es/moki/ratelimitj/redis/request/RequestLimitRuleJsonSerialiserTest.java
@@ -22,7 +22,7 @@ class RequestLimitRuleJsonSerialiserTest {
         ImmutableList<RequestLimitRule> rules = ImmutableList.of(RequestLimitRule.of(Duration.ofSeconds(10), 10L),
                 RequestLimitRule.of(Duration.ofMinutes(1), 20L));
 
-        assertThat(serialiser.encode(rules)).isEqualTo("[[10,10,10],[60,20,60]]");
+        assertThat(serialiser.encode(rules)).isEqualTo("[[10,10,10,0],[60,20,60,0]]");
     }
 
     @Test
@@ -32,7 +32,18 @@ class RequestLimitRuleJsonSerialiserTest {
         ImmutableList<RequestLimitRule> rules = ImmutableList.of(RequestLimitRule.of(Duration.ofSeconds(10), 10L).withPrecision(Duration.ofSeconds(4)),
                 RequestLimitRule.of(Duration.ofMinutes(1), 20L).withPrecision(Duration.ofSeconds(8)));
 
-        assertThat(serialiser.encode(rules)).isEqualTo("[[10,10,4],[60,20,8]]");
+        assertThat(serialiser.encode(rules)).isEqualTo("[[10,10,4,0],[60,20,8,0]]");
     }
 
+    @Test
+    @DisplayName("should encode limit rule with backoff in JSON array")
+    void shouldEncodeWithBackoff() {
+
+        ImmutableList<RequestLimitRule> rules = ImmutableList.of(
+                RequestLimitRule.of(Duration.ofSeconds(10), 10L).withBackoff(Duration.ofSeconds(15)),
+                RequestLimitRule.of(Duration.ofMinutes(1), 20L).withBackoff(Duration.ofMinutes(2))
+        );
+
+        assertThat(serialiser.encode(rules)).isEqualTo("[[10,10,10,15],[60,20,60,120]]");
+    }
 }


### PR DESCRIPTION
Hi @mokies, this is roughly the Idea I had about the issue https://github.com/mokies/ratelimitj/issues/52 I've opened.

Let me know what you think about it.

In case you agree with it we can decide which other tests we could add and documentation about it.

We should also decide about porting this feature to the other modules.

Additional info: 
Our ratelimit service has hundreds of integration tests, I plugged a build of this branch on my service here and all tests are passing still.